### PR TITLE
Fixed missing underscore in code example

### DIFF
--- a/components/charts.md
+++ b/components/charts.md
@@ -8,7 +8,7 @@ A basic chart can be created by specifying the Title, Type and Endpoint.
 
 ```text
 New-UDChart -Title "Threads by Process" -Type Doughnut -RefreshInterval 5 -Endpoint {  
-    Get-Process | ForEach-Object { [PSCustomObject]@{ Name = $_.Name; Threads = $.Threads.Count } } | Out-UDChartData -DataProperty "Threads" -LabelProperty "Name"  
+    Get-Process | ForEach-Object { [PSCustomObject]@{ Name = $_.Name; Threads = $_.Threads.Count } } | Out-UDChartData -DataProperty "Threads" -LabelProperty "Name"  
 } -Options @{  
      legend = @{  
          display = $false  


### PR DESCRIPTION
Missing underscore in `Threads = $_.Threads.Count ` caused error when trying to run code example.